### PR TITLE
Type safety

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,4 @@
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false

--- a/example/lib/same_variable_multiple_animations.dart
+++ b/example/lib/same_variable_multiple_animations.dart
@@ -11,9 +11,9 @@ class SameVariableAnimationPage extends StatefulWidget {
 
 class _SameVariableAnimationPageState extends State<SameVariableAnimationPage>
     with SingleTickerProviderStateMixin {
-  static const colorTag = SequenceAnimationTag<Color?>("color");
-  static const widthTag = SequenceAnimationTag<double>("width");
-  static const heightTag = SequenceAnimationTag<double>("height");
+  static final colorTag = SequenceAnimationTag<Color?>();
+  static final widthTag = SequenceAnimationTag<double>();
+  static final heightTag = SequenceAnimationTag<double>();
 
   late AnimationController controller;
   late SequenceAnimation sequenceAnimation;

--- a/example/lib/same_variable_multiple_animations.dart
+++ b/example/lib/same_variable_multiple_animations.dart
@@ -11,7 +11,7 @@ class SameVariableAnimationPage extends StatefulWidget {
 
 class _SameVariableAnimationPageState extends State<SameVariableAnimationPage>
     with SingleTickerProviderStateMixin {
-  static const colorTag = SequenceAnimationTag<Color>("color");
+  static const colorTag = SequenceAnimationTag<Color?>("color");
   static const widthTag = SequenceAnimationTag<double>("width");
   static const heightTag = SequenceAnimationTag<double>("height");
 

--- a/example/lib/same_variable_multiple_animations.dart
+++ b/example/lib/same_variable_multiple_animations.dart
@@ -5,56 +5,57 @@ import 'package:flutter_sequence_animation/flutter_sequence_animation.dart';
 
 class SameVariableAnimationPage extends StatefulWidget {
   @override
-  _SameVariableAnimationPageState createState() => new _SameVariableAnimationPageState();
+  _SameVariableAnimationPageState createState() =>
+      new _SameVariableAnimationPageState();
 }
 
-class _SameVariableAnimationPageState extends State<SameVariableAnimationPage> with SingleTickerProviderStateMixin{
-
+class _SameVariableAnimationPageState extends State<SameVariableAnimationPage>
+    with SingleTickerProviderStateMixin {
+  static const colorTag = SequenceAnimationTag<Color>("color");
+  static const widthTag = SequenceAnimationTag<double>("width");
+  static const heightTag = SequenceAnimationTag<double>("height");
 
   late AnimationController controller;
   late SequenceAnimation sequenceAnimation;
 
-
   @override
   void initState() {
     super.initState();
-    controller = new AnimationController(vsync: this, duration: const Duration(seconds: 5));
+    controller = new AnimationController(
+        vsync: this, duration: const Duration(seconds: 5));
 
     sequenceAnimation = new SequenceAnimationBuilder()
-      .addAnimatable(
+        .addAnimatable(
             animatable: new ColorTween(begin: Colors.red, end: Colors.yellow),
-            from:  const Duration(seconds: 0),
+            from: const Duration(seconds: 0),
             to: const Duration(seconds: 4),
-            tag: "color"
-        ).addAnimatable(
+            tag: colorTag)
+        .addAnimatable(
             animatable: new Tween<double>(begin: 50.0, end: 300.0),
-            from:  const Duration(seconds: 0),
+            from: const Duration(seconds: 0),
             to: const Duration(milliseconds: 3000),
-            tag: "width",
-            curve: Curves.easeIn
-        ).addAnimatable(
+            tag: widthTag,
+            curve: Curves.easeIn)
+        .addAnimatable(
             animatable: new Tween<double>(begin: 300.0, end: 100.0),
-            from:  const Duration(milliseconds: 3000),
+            from: const Duration(milliseconds: 3000),
             to: const Duration(milliseconds: 3700),
-            tag: "width",
-            curve: Curves.decelerate
-        ).addAnimatable(
+            tag: widthTag,
+            curve: Curves.decelerate)
+        .addAnimatable(
             animatable: new Tween<double>(begin: 50.0, end: 300.0),
-            from:  const Duration(seconds: 0),
+            from: const Duration(seconds: 0),
             to: const Duration(milliseconds: 3000),
-            tag: "height",
-            curve: Curves.ease
-        ).addAnimatable(
+            tag: heightTag,
+            curve: Curves.ease)
+        .addAnimatable(
             animatable: new Tween<double>(begin: 300.0, end: 450.0),
-            from:  const Duration(milliseconds: 3000),
+            from: const Duration(milliseconds: 3000),
             to: const Duration(milliseconds: 3800),
-            tag: "height",
-            curve: Curves.decelerate
-         ).animate(controller);
-
-
+            tag: heightTag,
+            curve: Curves.decelerate)
+        .animate(controller);
   }
-
 
   Future<Null> _playAnimation() async {
     try {
@@ -86,9 +87,9 @@ class _SameVariableAnimationPageState extends State<SameVariableAnimationPage> w
           builder: (context, child) {
             return new Center(
               child: new Container(
-                color: sequenceAnimation["color"].value,
-                height: sequenceAnimation["height"].value,
-                width: sequenceAnimation["width"].value,
+                color: sequenceAnimation.get(colorTag).value,
+                height: sequenceAnimation.get(heightTag).value,
+                width: sequenceAnimation.get(widthTag).value,
               ),
             );
           },
@@ -97,5 +98,4 @@ class _SameVariableAnimationPageState extends State<SameVariableAnimationPage> w
       ),
     );
   }
-
 }

--- a/example/lib/sequence_page.dart
+++ b/example/lib/sequence_page.dart
@@ -9,7 +9,7 @@ class SequencePage extends StatefulWidget {
 }
 
 class _SequencePageState extends State<SequencePage> with SingleTickerProviderStateMixin{
-  static const colorTag = SequenceAnimationTag<Color?>("color");
+  static final colorTag = SequenceAnimationTag<Color?>();
 
   late AnimationController controller;
   late SequenceAnimation sequenceAnimation;

--- a/example/lib/sequence_page.dart
+++ b/example/lib/sequence_page.dart
@@ -9,7 +9,7 @@ class SequencePage extends StatefulWidget {
 }
 
 class _SequencePageState extends State<SequencePage> with SingleTickerProviderStateMixin{
-  static const colorTag = SequenceAnimationTag<Color>("color");
+  static const colorTag = SequenceAnimationTag<Color?>("color");
 
   late AnimationController controller;
   late SequenceAnimation sequenceAnimation;

--- a/example/lib/sequence_page.dart
+++ b/example/lib/sequence_page.dart
@@ -9,7 +9,7 @@ class SequencePage extends StatefulWidget {
 }
 
 class _SequencePageState extends State<SequencePage> with SingleTickerProviderStateMixin{
-
+  static const colorTag = SequenceAnimationTag<Color>("color");
 
   late AnimationController controller;
   late SequenceAnimation sequenceAnimation;
@@ -25,19 +25,19 @@ class _SequencePageState extends State<SequencePage> with SingleTickerProviderSt
           animatable: new ColorTween(begin: Colors.red, end: Colors.yellow),
           from:  const Duration(seconds: 0),
           to: const Duration(seconds: 2),
-          tag: "color"
+          tag: colorTag
         ).addAnimatable(
           animatable: new ColorTween(begin: Colors.yellow, end: Colors.blueAccent),
           from:  const Duration(seconds: 2),
           to: const Duration(seconds: 4),
-          tag: "color",
+          tag: colorTag,
           curve: Curves.easeOut
         ).addAnimatable(
           animatable: new ColorTween(begin: Colors.blueAccent, end: Colors.pink),
           //  animatable: new Tween<double>(begin: 200.0, end: 40.0),
           from:  const Duration(seconds: 5),
           to: const Duration(seconds: 6),
-          tag: "color",
+          tag: colorTag,
           curve: Curves.fastOutSlowIn
         ).animate(controller);
 
@@ -75,7 +75,7 @@ class _SequencePageState extends State<SequencePage> with SingleTickerProviderSt
           builder: (context, child) {
             return new Center(
               child: new Container(
-                color: sequenceAnimation["color"].value,
+                color: sequenceAnimation.get(colorTag).value,
                 height: 200.0,
                 width: 200.0,
               ),

--- a/example/lib/staggered_animation_replication.dart
+++ b/example/lib/staggered_animation_replication.dart
@@ -10,6 +10,13 @@ class StaggeredAnimationReplication extends StatefulWidget {
 
 class _StaggeredAnimationReplicationState extends State<StaggeredAnimationReplication> with SingleTickerProviderStateMixin{
 
+  static const opacityKey = SequenceAnimationTag<double>("opacity");
+  static const widthKey = SequenceAnimationTag<double>("width");
+  static const heightKey = SequenceAnimationTag<double>("height");
+  static const paddingKey = SequenceAnimationTag<EdgeInsets>("padding");
+  static const borderRadiusKey = SequenceAnimationTag<BorderRadius>("borderRadius");
+  static const colorKey = SequenceAnimationTag<Color>("color");
+
   late AnimationController controller;
   late SequenceAnimation sequenceAnimation;
 
@@ -24,37 +31,37 @@ class _StaggeredAnimationReplicationState extends State<StaggeredAnimationReplic
         from: Duration.zero,
         to: const Duration(milliseconds: 200),
         curve: Curves.ease,
-        tag: "opacity"
+        tag: opacityKey
     ).addAnimatable(
         animatable: new Tween<double>(begin: 50.0, end: 150.0),
         from: const Duration(milliseconds: 250),
         to: const Duration(milliseconds: 500),
         curve: Curves.ease,
-        tag: "width"
+        tag: widthKey
     ).addAnimatable(
         animatable: new Tween<double>(begin: 50.0, end: 150.0),
         from: const Duration(milliseconds: 500),
         to: const Duration(milliseconds: 750),
         curve: Curves.ease,
-        tag: "height"
+        tag: heightKey
     ).addAnimatable(
         animatable: new EdgeInsetsTween(begin: const EdgeInsets.only(bottom: 16.0), end: const EdgeInsets.only(bottom: 75.0),),
         from: const Duration(milliseconds: 500),
         to: const Duration(milliseconds: 750),
         curve: Curves.ease,
-        tag: "padding"
+        tag: paddingKey
     ).addAnimatable(
         animatable: new BorderRadiusTween(begin: new BorderRadius.circular(4.0), end: new BorderRadius.circular(75.0),),
         from: const Duration(milliseconds: 750),
         to: const Duration(milliseconds: 1000),
         curve: Curves.ease,
-        tag: "borderRadius"
+        tag: borderRadiusKey
     ).addAnimatable(
         animatable: new ColorTween(begin: Colors.indigo[100], end: Colors.orange[400],),
         from: const Duration(milliseconds: 1000),
         to: const Duration(milliseconds: 1500),
         curve: Curves.ease,
-        tag: "color"
+        tag: colorKey
     ).animate(controller);
   }
 
@@ -66,20 +73,20 @@ class _StaggeredAnimationReplicationState extends State<StaggeredAnimationReplic
 
   Widget _buildAnimation(BuildContext context, Widget? child) {
     return new Container(
-      padding: sequenceAnimation["padding"].value,
+      padding: sequenceAnimation.get(paddingKey).value,
       alignment: Alignment.bottomCenter,
       child: new Opacity(
-        opacity: sequenceAnimation["opacity"].value,
+        opacity: sequenceAnimation.get(opacityKey).value ?? 0,
         child: new Container(
-          width: sequenceAnimation["width"].value,
-          height: sequenceAnimation["height"].value,
+          width: sequenceAnimation.get(widthKey).value,
+          height: sequenceAnimation.get(heightKey).value,
           decoration: new BoxDecoration(
-            color: sequenceAnimation["color"].value,
+            color: sequenceAnimation.get(colorKey).value,
             border: new Border.all(
               color: Colors.indigo[300]!,
               width: 3.0,
             ),
-            borderRadius: sequenceAnimation["borderRadius"].value,
+            borderRadius: sequenceAnimation.get(borderRadiusKey).value,
           ),
         ),
       ),

--- a/example/lib/staggered_animation_replication.dart
+++ b/example/lib/staggered_animation_replication.dart
@@ -15,7 +15,7 @@ class _StaggeredAnimationReplicationState extends State<StaggeredAnimationReplic
   static const heightKey = SequenceAnimationTag<double>("height");
   static const paddingKey = SequenceAnimationTag<EdgeInsets>("padding");
   static const borderRadiusKey = SequenceAnimationTag<BorderRadius>("borderRadius");
-  static const colorKey = SequenceAnimationTag<Color>("color");
+  static const colorKey = SequenceAnimationTag<Color?>("color");
 
   late AnimationController controller;
   late SequenceAnimation sequenceAnimation;
@@ -76,7 +76,7 @@ class _StaggeredAnimationReplicationState extends State<StaggeredAnimationReplic
       padding: sequenceAnimation.get(paddingKey).value,
       alignment: Alignment.bottomCenter,
       child: new Opacity(
-        opacity: sequenceAnimation.get(opacityKey).value ?? 0,
+        opacity: sequenceAnimation.get(opacityKey).value,
         child: new Container(
           width: sequenceAnimation.get(widthKey).value,
           height: sequenceAnimation.get(heightKey).value,

--- a/example/lib/staggered_animation_replication.dart
+++ b/example/lib/staggered_animation_replication.dart
@@ -10,12 +10,12 @@ class StaggeredAnimationReplication extends StatefulWidget {
 
 class _StaggeredAnimationReplicationState extends State<StaggeredAnimationReplication> with SingleTickerProviderStateMixin{
 
-  static const opacityKey = SequenceAnimationTag<double>("opacity");
-  static const widthKey = SequenceAnimationTag<double>("width");
-  static const heightKey = SequenceAnimationTag<double>("height");
-  static const paddingKey = SequenceAnimationTag<EdgeInsets>("padding");
-  static const borderRadiusKey = SequenceAnimationTag<BorderRadius>("borderRadius");
-  static const colorKey = SequenceAnimationTag<Color?>("color");
+  static final opacityKey = SequenceAnimationTag<double>();
+  static final widthKey = SequenceAnimationTag<double>();
+  static final heightKey = SequenceAnimationTag<double>();
+  static final paddingKey = SequenceAnimationTag<EdgeInsets>();
+  static final borderRadiusKey = SequenceAnimationTag<BorderRadius>();
+  static final colorKey = SequenceAnimationTag<Color?>();
 
   late AnimationController controller;
   late SequenceAnimation sequenceAnimation;

--- a/lib/flutter_sequence_animation.dart
+++ b/lib/flutter_sequence_animation.dart
@@ -9,19 +9,19 @@ class _AnimationInformation<T> {
     required this.tag,
   });
 
-  final Animatable<T?> animatable;
+  final Animatable<T> animatable;
   final Duration from;
   final Duration to;
   final Curve curve;
   final SequenceAnimationTag<T> tag;
 
-  IntervalAnimatable<T?> createIntervalAnimatable({
-    required Animatable<T?> animatable,
-    required Animatable<T?> defaultAnimatable,
+  IntervalAnimatable<T> createIntervalAnimatable({
+    required Animatable<T> animatable,
+    required Animatable<T> defaultAnimatable,
     required double begin,
     required double end,
   }) =>
-      IntervalAnimatable<T?>(
+      IntervalAnimatable<T>(
         animatable: animatable,
         defaultAnimatable: defaultAnimatable,
         begin: begin,
@@ -78,7 +78,7 @@ class SequenceAnimationBuilder {
   ///
   /// The animation with tag "animation" will start at second 3 and run until second 4.
   ///
-  SequenceAnimationBuilder addAnimatableAfterLastOneWithTag<T, A extends Animatable<T?>>({
+  SequenceAnimationBuilder addAnimatableAfterLastOneWithTag<T, A extends Animatable<T>>({
     required Object lastTag,
     required A animatable,
     Duration delay: Duration.zero,
@@ -126,7 +126,7 @@ class SequenceAnimationBuilder {
   ///
   /// The animation with tag "animation" will start at second 3 and run until second 4.
   ///
-  SequenceAnimationBuilder addAnimatableAfterLastOne<T, A extends Animatable<T?>>({
+  SequenceAnimationBuilder addAnimatableAfterLastOne<T, A extends Animatable<T>>({
     required A animatable,
     Duration delay: Duration.zero,
     required Duration duration,
@@ -147,7 +147,7 @@ class SequenceAnimationBuilder {
   /// Convenient wrapper around to specify an animatable using a duration instead of end point
   ///
   /// Instead of specifying from and to, you specify start and duration
-  SequenceAnimationBuilder addAnimatableUsingDuration<T, A extends Animatable<T?>>({
+  SequenceAnimationBuilder addAnimatableUsingDuration<T, A extends Animatable<T>>({
     required A animatable,
     required Duration start,
     required Duration duration,
@@ -183,7 +183,7 @@ class SequenceAnimationBuilder {
   ///         .animate(controller);
   /// ```
   ///
-  SequenceAnimationBuilder addAnimatable<T, A extends Animatable<T?>>({
+  SequenceAnimationBuilder addAnimatable<T, A extends Animatable<T>>({
     required A animatable,
     required Duration from,
     required Duration to,
@@ -262,11 +262,11 @@ class SequenceAnimation {
   SequenceAnimation._internal(this._animations);
 
   /// Returns the animation with a given tag, this animation is tied to the controller.
-  Animation<T?> get<T>(SequenceAnimationTag<T> tag) {
+  Animation<T> get<T>(SequenceAnimationTag<T> tag) {
     assert(_animations.containsKey(tag),
         "There was no animatable with the tag: ${tag.value}");
 
-    return _animations[tag]! as Animation<T?>;
+    return _animations[tag]! as Animation<T>;
   }
 }
 
@@ -301,7 +301,7 @@ class IntervalAnimatable<T> extends Animatable<T> {
   }
 }
 
-extension _Chain<T> on Animatable<T> {
+extension Chain<T> on Animatable<T> {
   /// Chains an [Animatable] with a [CurveTween] and the given [Interval].
   /// Basically, the animation is being constrained to the given interval
   Animatable<T> chainCurve(Interval interval) {

--- a/lib/flutter_sequence_animation.dart
+++ b/lib/flutter_sequence_animation.dart
@@ -29,7 +29,23 @@ class _AnimationInformation<T> {
       );
 }
 
-class SequenceAnimationTag<T> {}
+class SequenceAnimationTag<T> {
+  SequenceAnimationTag() : id = _id++;
+
+  const SequenceAnimationTag.id(this.id);
+
+  static int _id = 0;
+
+  final Object id;
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SequenceAnimationTag &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+  @override
+  int get hashCode => id.hashCode;
+}
 
 class SequenceAnimationBuilder {
   List<_AnimationInformation> _animations = [];

--- a/lib/flutter_sequence_animation.dart
+++ b/lib/flutter_sequence_animation.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 
-class _AnimationInformation {
+class _AnimationInformation<T, A extends Animatable<T?>> {
   _AnimationInformation({
     required this.animatable,
     required this.from,
@@ -10,22 +9,48 @@ class _AnimationInformation {
     required this.tag,
   });
 
-  final Animatable animatable;
+  final A animatable;
   final Duration from;
   final Duration to;
   final Curve curve;
-  final Object tag;
+  final SequenceAnimationTag<T> tag;
+
+  IntervalAnimatable<T?> createIntervalAnimatable({
+    required Animatable<T?> animatable,
+    required Animatable<T?> defaultAnimatable,
+    required double begin,
+    required double end,
+  }) =>
+      IntervalAnimatable<T?>(
+        animatable: animatable,
+        defaultAnimatable: defaultAnimatable,
+        begin: begin,
+        end: end,
+      );
+}
+
+class SequenceAnimationTag<T> {
+  const SequenceAnimationTag(this.value);
+  final Object value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SequenceAnimationTag &&
+          runtimeType == other.runtimeType &&
+          value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 class SequenceAnimationBuilder {
   List<_AnimationInformation> _animations = [];
 
-
   // Returns the duration of the current animation chain
   Duration getCurrentDuration() {
     return Duration(microseconds: _currentLengthInMicroSeconds());
   }
-
 
   /// Convenient wrapper to add an animatable after the last one with a specific tag finished is finished
   ///
@@ -53,19 +78,29 @@ class SequenceAnimationBuilder {
   ///
   /// The animation with tag "animation" will start at second 3 and run until second 4.
   ///
-  SequenceAnimationBuilder addAnimatableAfterLastOneWithTag({
+  SequenceAnimationBuilder addAnimatableAfterLastOneWithTag<T, A extends Animatable<T?>>({
     required Object lastTag,
-    required Animatable animatable,
+    required A animatable,
     Duration delay: Duration.zero,
     required Duration duration,
     Curve curve: Curves.linear,
-    required Object tag,
+    required SequenceAnimationTag<T> tag,
   }) {
-    assert(_animations.isNotEmpty, "Can not add animatable after last one if there is no animatable yet");
-    var start = _animations.cast<_AnimationInformation?>().lastWhere((it) => it?.tag == lastTag, orElse: () => null)?.to;
-    assert(start != null, "Animation with tag $lastTag can not be found before $tag");
+    assert(_animations.isNotEmpty,
+        "Can not add animatable after last one if there is no animatable yet");
+    var start = _animations
+        .cast<_AnimationInformation?>()
+        .lastWhere((it) => it?.tag == lastTag, orElse: () => null)
+        ?.to;
+    assert(start != null,
+        "Animation with tag $lastTag can not be found before $tag");
     start!;
-    return addAnimatable(animatable: animatable, from: start + delay, to: start + delay + duration, tag: tag, curve: curve);
+    return addAnimatable(
+        animatable: animatable,
+        from: start + delay,
+        to: start + delay + duration,
+        tag: tag,
+        curve: curve);
   }
 
   /// Convenient wrapper to add an animatable after the last one is finished
@@ -91,29 +126,40 @@ class SequenceAnimationBuilder {
   ///
   /// The animation with tag "animation" will start at second 3 and run until second 4.
   ///
-  SequenceAnimationBuilder addAnimatableAfterLastOne({
-    required Animatable animatable,
+  SequenceAnimationBuilder addAnimatableAfterLastOne<T, A extends Animatable<T?>>({
+    required A animatable,
     Duration delay: Duration.zero,
     required Duration duration,
     Curve curve: Curves.linear,
-    required Object tag,
+    required SequenceAnimationTag<T> tag,
   }) {
-    assert(_animations.isNotEmpty, "Can not add animatable after last one if there is no animatable yet");
+    assert(_animations.isNotEmpty,
+        "Can not add animatable after last one if there is no animatable yet");
     var start = _animations.last.to;
-    return addAnimatable(animatable: animatable, from: start + delay, to: start + delay + duration, tag: tag, curve: curve);
+    return addAnimatable(
+        animatable: animatable,
+        from: start + delay,
+        to: start + delay + duration,
+        tag: tag,
+        curve: curve);
   }
 
   /// Convenient wrapper around to specify an animatable using a duration instead of end point
   ///
   /// Instead of specifying from and to, you specify start and duration
-  SequenceAnimationBuilder addAnimatableUsingDuration({
-    required Animatable animatable,
+  SequenceAnimationBuilder addAnimatableUsingDuration<T, A extends Animatable<T?>>({
+    required A animatable,
     required Duration start,
     required Duration duration,
     Curve curve: Curves.linear,
-    required Object tag,
-    }) {
-    return addAnimatable(animatable: animatable, from: start, to: start + duration, tag: tag, curve: curve);
+    required SequenceAnimationTag<T> tag,
+  }) {
+    return addAnimatable(
+        animatable: animatable,
+        from: start,
+        to: start + duration,
+        tag: tag,
+        curve: curve);
   }
 
   /// Adds an [Animatable] to the sequence, in the most cases this would be a [Tween].
@@ -137,15 +183,16 @@ class SequenceAnimationBuilder {
   ///         .animate(controller);
   /// ```
   ///
-  SequenceAnimationBuilder addAnimatable({
-    required Animatable animatable,
+  SequenceAnimationBuilder addAnimatable<T, A extends Animatable<T?>>({
+    required A animatable,
     required Duration from,
     required Duration to,
     Curve curve: Curves.linear,
-    required Object tag,
+    required SequenceAnimationTag<T> tag,
   }) {
+    assert(T.toString() != 'Object');
     assert(to >= from);
-    _animations.add(new _AnimationInformation(
+    _animations.add(new _AnimationInformation<T, A>(
         animatable: animatable, from: from, to: to, curve: curve, tag: tag));
     return this;
   }
@@ -167,9 +214,9 @@ class SequenceAnimationBuilder {
     // Sets the duration of the controller
     controller.duration = new Duration(microseconds: longestTimeMicro);
 
-    Map<Object, Animatable> animatables = {};
-    Map<Object, double> begins = {};
-    Map<Object, double> ends = {};
+    Map<SequenceAnimationTag, Animatable> animatables = {};
+    Map<SequenceAnimationTag, double> begins = {};
+    Map<SequenceAnimationTag, double> ends = {};
 
     _animations.forEach((info) {
       assert(info.to.inMicroseconds <= longestTimeMicro);
@@ -178,8 +225,7 @@ class SequenceAnimationBuilder {
       double end = info.to.inMicroseconds / longestTimeMicro;
       Interval intervalCurve = new Interval(begin, end, curve: info.curve);
       if (animatables[info.tag] == null) {
-        animatables[info.tag] =
-            IntervalAnimatable.chainCurve(info.animatable, intervalCurve);
+        animatables[info.tag] = info.animatable.chainCurve(intervalCurve);
         begins[info.tag] = begin;
         ends[info.tag] = end;
       } else {
@@ -188,12 +234,10 @@ class SequenceAnimationBuilder {
             "When animating the same property you need to: \n"
             "a) Have them not overlap \n"
             "b) Add them in an ordered fashion\n"
-            "Animation with tag ${info.tag} ends at ${ends[info.tag]} but also begins at $begin"
-        );
-        animatables[info.tag] = new IntervalAnimatable(
+            "Animation with tag ${info.tag} ends at ${ends[info.tag]} but also begins at $begin");
+        animatables[info.tag] = info.createIntervalAnimatable(
           animatable: animatables[info.tag]!,
-          defaultAnimatable:
-              IntervalAnimatable.chainCurve(info.animatable, intervalCurve),
+          defaultAnimatable: info.animatable.chainCurve(intervalCurve),
           begin: begins[info.tag]!,
           end: ends[info.tag]!,
         );
@@ -201,7 +245,7 @@ class SequenceAnimationBuilder {
       }
     });
 
-    Map<Object, Animation> result = {};
+    Map<SequenceAnimationTag, Animation> result = {};
 
     animatables.forEach((tag, animInfo) {
       result[tag] = animInfo.animate(controller);
@@ -212,16 +256,17 @@ class SequenceAnimationBuilder {
 }
 
 class SequenceAnimation {
-  final Map<Object, Animation> _animations;
+  final Map<SequenceAnimationTag, Animation> _animations;
 
   /// Use the [SequenceAnimationBuilder] to construct this class.
   SequenceAnimation._internal(this._animations);
 
   /// Returns the animation with a given tag, this animation is tied to the controller.
-  Animation operator [](Object key) {
-    assert(_animations.containsKey(key),
-        "There was no animatable with the key: $key");
-    return _animations[key]!;
+  Animation<T?> get<T>(SequenceAnimationTag<T> tag) {
+    assert(_animations.containsKey(tag),
+        "There was no animatable with the tag: ${tag.value}");
+
+    return _animations[tag]! as Animation<T?>;
   }
 }
 
@@ -235,8 +280,8 @@ class IntervalAnimatable<T> extends Animatable<T> {
     required this.end,
   });
 
-  final Animatable animatable;
-  final Animatable defaultAnimatable;
+  final Animatable<T> animatable;
+  final Animatable<T> defaultAnimatable;
 
   /// The relative begin to of [animatable]
   /// If your [AnimationController] is running from 0->1, this needs to be a value between those two
@@ -246,12 +291,6 @@ class IntervalAnimatable<T> extends Animatable<T> {
   /// If your [AnimationController] is running from 0->1, this needs to be a value between those two
   final double end;
 
-  /// Chains an [Animatable] with a [CurveTween] and the given [Interval].
-  /// Basically, the animation is being constrained to the given interval
-  static Animatable chainCurve(Animatable parent, Interval interval) {
-    return parent.chain(new CurveTween(curve: interval));
-  }
-
   @override
   T transform(double t) {
     if (t >= begin && t <= end) {
@@ -259,5 +298,13 @@ class IntervalAnimatable<T> extends Animatable<T> {
     } else {
       return defaultAnimatable.transform(t);
     }
+  }
+}
+
+extension _Chain<T> on Animatable<T> {
+  /// Chains an [Animatable] with a [CurveTween] and the given [Interval].
+  /// Basically, the animation is being constrained to the given interval
+  Animatable<T> chainCurve(Interval interval) {
+    return chain(new CurveTween(curve: interval));
   }
 }

--- a/lib/flutter_sequence_animation.dart
+++ b/lib/flutter_sequence_animation.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class _AnimationInformation<T, A extends Animatable<T?>> {
+class _AnimationInformation<T> {
   _AnimationInformation({
     required this.animatable,
     required this.from,
@@ -9,7 +9,7 @@ class _AnimationInformation<T, A extends Animatable<T?>> {
     required this.tag,
   });
 
-  final A animatable;
+  final Animatable<T?> animatable;
   final Duration from;
   final Duration to;
   final Curve curve;
@@ -192,7 +192,7 @@ class SequenceAnimationBuilder {
   }) {
     assert(T.toString() != 'Object');
     assert(to >= from);
-    _animations.add(new _AnimationInformation<T, A>(
+    _animations.add(new _AnimationInformation<T>(
         animatable: animatable, from: from, to: to, curve: curve, tag: tag));
     return this;
   }

--- a/lib/flutter_sequence_animation.dart
+++ b/lib/flutter_sequence_animation.dart
@@ -29,20 +29,7 @@ class _AnimationInformation<T> {
       );
 }
 
-class SequenceAnimationTag<T> {
-  const SequenceAnimationTag(this.value);
-  final Object value;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is SequenceAnimationTag &&
-          runtimeType == other.runtimeType &&
-          value == other.value;
-
-  @override
-  int get hashCode => value.hashCode;
-}
+class SequenceAnimationTag<T> {}
 
 class SequenceAnimationBuilder {
   List<_AnimationInformation> _animations = [];
@@ -264,7 +251,7 @@ class SequenceAnimation {
   /// Returns the animation with a given tag, this animation is tied to the controller.
   Animation<T> get<T>(SequenceAnimationTag<T> tag) {
     assert(_animations.containsKey(tag),
-        "There was no animatable with the tag: ${tag.value}");
+        "There was no animatable with the tag: $tag");
 
     return _animations[tag]! as Animation<T>;
   }

--- a/test/animation_sequence_tests.dart
+++ b/test/animation_sequence_tests.dart
@@ -25,7 +25,7 @@ void main() {
 
     expect(controller.duration, isNull);
 
-    String seqKey = "color";
+    const seqKey = const SequenceAnimationTag<Color>("color");
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(
         tag: seqKey,
@@ -39,7 +39,7 @@ void main() {
     expect(controller.duration, isNotNull);
 
 
-    ValueKey key = new ValueKey("color");
+    final key = new ValueKey("color");
     
     // Build our app and trigger a frame.
     await tester.pumpWidget(new AnimatedBuilder(animation: controller, builder: (context, child) {
@@ -47,7 +47,7 @@ void main() {
         key: key,
         width: 200.0,
         height: 200.0,
-        color: sequenceAnimation[seqKey].value,
+        color: sequenceAnimation.get(seqKey).value,
       );
     }));
 
@@ -74,10 +74,11 @@ void main() {
 
     expect(controller.duration, isNull);
 
-    String seqKey = "color";
+    const seqKey = const SequenceAnimationTag<Color>("color");
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(
         tag: seqKey,
+        //animatable: Tween<double>(),
         animatable: new ColorTween(begin: Colors.red, end: Colors.blue),
         from: const Duration(seconds: 0),
         to: const Duration(seconds: 1))
@@ -103,7 +104,7 @@ void main() {
     expect(controller.duration, equals(const Duration(seconds: 4)));
 
 
-    ValueKey key = new ValueKey("color");
+    final key = new ValueKey("color");
 
     // Build our app and trigger a frame.
     await tester.pumpWidget(new AnimatedBuilder(animation: controller, builder: (context, child) {
@@ -111,7 +112,7 @@ void main() {
         key: key,
         width: 200.0,
         height: 200.0,
-        color: sequenceAnimation[seqKey].value,
+        color: sequenceAnimation.get(seqKey).value,
       );
     }));
 
@@ -137,7 +138,7 @@ void main() {
 
     expect(controller.duration, isNull);
 
-    String seqKey = "color";
+    const seqKey = const SequenceAnimationTag<Color>("color");
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(
         tag: seqKey,
@@ -163,7 +164,7 @@ void main() {
     expect(controller.duration, equals(const Duration(seconds: 4)));
 
 
-    ValueKey key = new ValueKey("color");
+    final key = new ValueKey("color");
 
     // Build our app and trigger a frame.
     await tester.pumpWidget(new AnimatedBuilder(animation: controller, builder: (context, child) {
@@ -171,7 +172,7 @@ void main() {
         key: key,
         width: 200.0,
         height: 200.0,
-        color: sequenceAnimation[seqKey].value,
+        color: sequenceAnimation.get(seqKey).value,
       );
     }));
 
@@ -204,7 +205,7 @@ void main() {
     expect(controller.duration, equals(const Duration(seconds: 0)));
 
     try {
-      sequenceAnimation["doesntExit"];
+      sequenceAnimation.get(SequenceAnimationTag<bool>("doesntExit"));
     } catch(e) {
       expect(e,isAssertionError);
     }
@@ -224,8 +225,9 @@ void main() {
 
     expect(controller.duration, isNull);
 
-    String colorKey = "color";
-    String widthKey = "width";
+    const colorKey = const SequenceAnimationTag<Color>("color");
+    const widthKey = const SequenceAnimationTag<double>("width");
+
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(
         tag: colorKey,
@@ -234,7 +236,7 @@ void main() {
         to: const Duration(seconds: 1))
         .addAnimatable(
         tag: widthKey,
-        animatable: new Tween<double>(begin: 50.0, end: 500.0),
+        animatable: new Tween(begin: 50.0, end: 500.0),
         from: const Duration(seconds: 1),
         to: const Duration(seconds: 5))
         .addAnimatable(
@@ -259,15 +261,15 @@ void main() {
     expect(controller.duration, equals(const Duration(seconds: 5)));
 
 
-    ValueKey key = new ValueKey("color");
+    final key = new ValueKey("color");
 
     // Build our app and trigger a frame.
     await tester.pumpWidget(new AnimatedBuilder(animation: controller, builder: (context, child) {
       return new Container(
         key: key,
-        width: sequenceAnimation[widthKey].value,
+        width: sequenceAnimation.get(widthKey).value,
         height: 200.0,
-        color: sequenceAnimation[colorKey].value,
+        color: sequenceAnimation.get(colorKey).value,
       );
     }));
 
@@ -299,15 +301,17 @@ void main() {
 
     AnimationController controller = new AnimationController(vsync: const TestVSync());
 
+    const tag = const SequenceAnimationTag<Color>("s");
+
     try {
       new SequenceAnimationBuilder()
           .addAnimatable(
-          tag: "s",
+          tag: tag,
           animatable: new ColorTween(begin: Colors.red, end: Colors.yellow),
           from: const Duration(seconds: 0),
           to: const Duration(seconds: 2))
           .addAnimatable(
-          tag: "s",
+          tag: tag,
           animatable: new ColorTween(begin: Colors.red, end: Colors.yellow),
           from: const Duration(seconds: 1),
           to: const Duration(seconds: 2))
@@ -320,12 +324,12 @@ void main() {
     try {
       new SequenceAnimationBuilder()
           .addAnimatable(
-          tag: "s",
+          tag: tag,
           animatable: new ColorTween(begin: Colors.red, end: Colors.yellow),
           from: const Duration(seconds: 0),
           to: const Duration(milliseconds: 2000))
           .addAnimatable(
-          tag: "s",
+          tag: tag,
           animatable: new ColorTween(begin: Colors.red, end: Colors.yellow),
           from: const Duration(milliseconds: 1999),
           to: const Duration(milliseconds: 2001))
@@ -336,32 +340,12 @@ void main() {
   });
 
 
-  testWidgets('Same tag but different types', (WidgetTester tester) async {
-    AnimationController controller = new AnimationController(vsync: const TestVSync());
-    try {
-      new SequenceAnimationBuilder()
-          .addAnimatable(
-          tag: "s",
-          animatable: new ColorTween(begin: Colors.red, end: Colors.yellow),
-          from: const Duration(seconds: 0),
-          to: const Duration(seconds: 2))
-          .addAnimatable(
-          tag: "s",
-          animatable: new Tween<double>(begin: 0.0, end: 100.0),
-          from: const Duration(seconds: 3),
-          to: const Duration(seconds: 4))
-          .animate(controller);
-    } catch(e) {
-      expect(e, isAssertionError);
-    }
-  });
-
-
   testWidgets('Uses object key', (WidgetTester tester) async {
 
     AnimationController controller = new AnimationController(vsync: const TestVSync());
 
-    Object seqKey = false;
+    const seqKey = const SequenceAnimationTag<Color>(false);
+
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(
         tag: seqKey,
@@ -375,7 +359,7 @@ void main() {
     expect(controller.duration, isNotNull);
 
 
-    ValueKey key = new ValueKey("color");
+    final key = new ValueKey("color");
 
     // Build our app and trigger a frame.
     await tester.pumpWidget(new AnimatedBuilder(animation: controller, builder: (context, child) {
@@ -383,7 +367,7 @@ void main() {
         key: key,
         width: 200.0,
         height: 200.0,
-        color: sequenceAnimation[seqKey].value,
+        color: sequenceAnimation.get(seqKey).value,
       );
     }));
 

--- a/test/animation_sequence_tests.dart
+++ b/test/animation_sequence_tests.dart
@@ -25,7 +25,7 @@ void main() {
 
     expect(controller.duration, isNull);
 
-    const seqKey = const SequenceAnimationTag<Color>("color");
+    const seqKey = const SequenceAnimationTag<Color?>("color");
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(
         tag: seqKey,
@@ -74,7 +74,7 @@ void main() {
 
     expect(controller.duration, isNull);
 
-    const seqKey = const SequenceAnimationTag<Color>("color");
+    const seqKey = const SequenceAnimationTag<Color?>("color");
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(
         tag: seqKey,
@@ -138,7 +138,7 @@ void main() {
 
     expect(controller.duration, isNull);
 
-    const seqKey = const SequenceAnimationTag<Color>("color");
+    const seqKey = const SequenceAnimationTag<Color?>("color");
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(
         tag: seqKey,
@@ -225,7 +225,7 @@ void main() {
 
     expect(controller.duration, isNull);
 
-    const colorKey = const SequenceAnimationTag<Color>("color");
+    const colorKey = const SequenceAnimationTag<Color?>("color");
     const widthKey = const SequenceAnimationTag<double>("width");
 
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
@@ -301,7 +301,7 @@ void main() {
 
     AnimationController controller = new AnimationController(vsync: const TestVSync());
 
-    const tag = const SequenceAnimationTag<Color>("s");
+    const tag = const SequenceAnimationTag<Color?>("s");
 
     try {
       new SequenceAnimationBuilder()
@@ -344,7 +344,7 @@ void main() {
 
     AnimationController controller = new AnimationController(vsync: const TestVSync());
 
-    const seqKey = const SequenceAnimationTag<Color>(false);
+    const seqKey = const SequenceAnimationTag<Color?>(false);
 
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(

--- a/test/animation_sequence_tests.dart
+++ b/test/animation_sequence_tests.dart
@@ -25,7 +25,7 @@ void main() {
 
     expect(controller.duration, isNull);
 
-    const seqKey = const SequenceAnimationTag<Color?>("color");
+    final seqKey = SequenceAnimationTag<Color?>();
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(
         tag: seqKey,
@@ -74,7 +74,7 @@ void main() {
 
     expect(controller.duration, isNull);
 
-    const seqKey = const SequenceAnimationTag<Color?>("color");
+    final seqKey = SequenceAnimationTag<Color?>();
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(
         tag: seqKey,
@@ -138,7 +138,7 @@ void main() {
 
     expect(controller.duration, isNull);
 
-    const seqKey = const SequenceAnimationTag<Color?>("color");
+    final seqKey = SequenceAnimationTag<Color?>();
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(
         tag: seqKey,
@@ -205,7 +205,7 @@ void main() {
     expect(controller.duration, equals(const Duration(seconds: 0)));
 
     try {
-      sequenceAnimation.get(SequenceAnimationTag<bool>("doesntExit"));
+      sequenceAnimation.get(SequenceAnimationTag<bool>());
     } catch(e) {
       expect(e,isAssertionError);
     }
@@ -225,8 +225,8 @@ void main() {
 
     expect(controller.duration, isNull);
 
-    const colorKey = const SequenceAnimationTag<Color?>("color");
-    const widthKey = const SequenceAnimationTag<double>("width");
+    final colorKey = SequenceAnimationTag<Color?>();
+    final widthKey = SequenceAnimationTag<double>();
 
     SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
         .addAnimatable(
@@ -301,7 +301,7 @@ void main() {
 
     AnimationController controller = new AnimationController(vsync: const TestVSync());
 
-    const tag = const SequenceAnimationTag<Color?>("s");
+    final tag = SequenceAnimationTag<Color?>();
 
     try {
       new SequenceAnimationBuilder()
@@ -338,54 +338,4 @@ void main() {
       expect(e, isAssertionError);
     }
   });
-
-
-  testWidgets('Uses object key', (WidgetTester tester) async {
-
-    AnimationController controller = new AnimationController(vsync: const TestVSync());
-
-    const seqKey = const SequenceAnimationTag<Color?>(false);
-
-    SequenceAnimation sequenceAnimation = new SequenceAnimationBuilder()
-        .addAnimatable(
-        tag: seqKey,
-        animatable: new ColorTween(begin: Colors.red, end: Colors.yellow),
-        from: const Duration(seconds: 0),
-        to: const Duration(seconds: 1))
-        .animate(controller);
-
-
-
-    expect(controller.duration, isNotNull);
-
-
-    final key = new ValueKey("color");
-
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(new AnimatedBuilder(animation: controller, builder: (context, child) {
-      return new Container(
-        key: key,
-        width: 200.0,
-        height: 200.0,
-        color: sequenceAnimation.get(seqKey).value,
-      );
-    }));
-
-
-    expect(find.byKey(key), findsOneWidget);
-    Color color = tester.widget<Container>(find.byKey(key)).color!;
-    expect(color, Colors.red);
-
-
-    controller.forward();
-    await tester.pumpAndSettle();
-
-
-    color = tester.widget<Container>(find.byKey(key)).color!;
-    expect(color, Colors.yellow);
-
-
-  });
 }
-
-


### PR DESCRIPTION
Hi,
thank you very much for your work on this package. It's been my favorite animation add-on since its very first version years ago!

I've been thinking about a little revamp of the API in order to make it more sound at compile-time.
It leverages tags/keys that are generics on the animation type they want to represent, so that it's guaranteed that you can only add animatables (for example tweens) of the given tag type and also extract values of the animatable while using them for the animation at a later time.

I'll submit this as a draft PR because, if you like the approach, some work needs to be done in order to handle backward compatibility and reword the docs.

